### PR TITLE
Ubuntu 14.04.02 Install

### DIFF
--- a/python/README.txt
+++ b/python/README.txt
@@ -1,5 +1,9 @@
-This directory contains post-processing analysis tools.
+This directory contains post-processing analysis tools plus install script.
 
 plot_log_timestamp.py  - Plots timestamp information from a log file based on
                          the command name present in the file.
+
+install_ubuntu.py      - Install script for Ubuntu 14.04.02 that installs the
+                         required dependencies and compiles bulk_extractor 
+                         1.5.5-dev with hashdb 2.0.1.
 

--- a/python/install_ubuntu.py
+++ b/python/install_ubuntu.py
@@ -1,0 +1,13 @@
+#!/usr/bin/python
+# 
+#  Ubuntu 14.04.02
+#
+
+import os
+
+os.system('sudo apt-get -y install gcc g++ openssl flex libewf-dev libxml2-dev libssl-dev libtre-dev libtool p7zip')
+os.system('wget http://digitalcorpora.org/downloads/hashdb/bulk_extractor-1.5.5-dev.tar.gz')
+os.system('tar -zxvf bulk_extractor-1.5.5-dev.tar.gz')
+os.system('cd bulk_extractor-1.5.5-dev && wget http://digitalcorpora.org/downloads/hashdb/hashdb-2.0.1.tar.gz && tar -zxvf hashdb-2.0.1.tar.gz')
+os.system('cd bulk_extractor-1.5.5-dev/hashdb-2.0.1 && ./configure && make && sudo make install')
+os.system('cd bulk_extractor-1.5.5-dev && ./configure && make && sudo make install')


### PR DESCRIPTION
Install script for Ubuntu 14.04.02 that installs the required dependencies and compiles bulk_extractor 1.5.5-dev with hashdb 2.0.1.